### PR TITLE
pelicanfly broken under pelican-3.7: MD_EXTENSIONS vs. MARKDOWN

### DIFF
--- a/pelicanfly/pelicanfly.py
+++ b/pelicanfly/pelicanfly.py
@@ -1,4 +1,5 @@
 import os
+import sys
 from pelican import signals
 from fontawesome_markdown import FontAwesomeExtension
 
@@ -6,12 +7,19 @@ from fontawesome_markdown import FontAwesomeExtension
 def add_md_ext_and_static(peli):
     md_ext = peli.settings.get('MD_EXTENSIONS')
     cls = FontAwesomeExtension
-    inst = cls()
-    if not md_ext:
-        peli.settings['MD_EXTENSIONS'] = [inst]
-    elif not any([isinstance(ext, cls) for ext in md_ext]):
-        md_ext.append(inst)
-        peli.settings['MD_EXTENSIONS'] = md_ext
+    inst = FontAwesomeExtension()
+    try:
+        if isinstance(peli.settings.get('MD_EXTENSIONS'), list): # pelican 3.6.3 and earlier
+            if not md_ext:
+                peli.settings['MD_EXTENSIONS'] = [inst]
+            elif not any([isinstance(ext, cls) for ext in md_ext]):
+                peli.settings['MD_EXTENSIONS'].append(inst)
+        else:
+            peli.settings['MARKDOWN'].setdefault('extensions', []).append(inst)
+    except:
+        sys.excepthook(*sys.exc_info())
+        sys.stderr.write("\nError - the fontawesome_markdown extension failed to configure.\n")
+        sys.stderr.flush()
     pelifly_static = os.path.join(os.path.split(__file__)[0], 'static')
     peli.settings['THEME_STATIC_PATHS'].append(pelifly_static)
 

--- a/pelicanfly/tests/test_pelicanfly.py
+++ b/pelicanfly/tests/test_pelicanfly.py
@@ -35,8 +35,13 @@ class TestPelicanfly(unittest.TestCase):
         pass
 
     def test_add_markdown_plugin(self):
-        added = any([isinstance(x,FontAwesomeExtension)
-            for x in self.pelican.settings['MD_EXTENSIONS']])
+        if 'MD_EXTENSIONS' in self.pelican.settings.keys():
+            # pelican 3.6.3 and earlier
+            added = any([isinstance(x,FontAwesomeExtension)
+                for x in self.pelican.settings['MD_EXTENSIONS']])
+        else:
+            added = any([isinstance(x,FontAwesomeExtension)
+                for x in self.pelican.settings['MARKDOWN']['extensions']])
         self.assertTrue(added)
 
     def test_add_static_paths(self):


### PR DESCRIPTION
MD_EXTENSIONS is deprecated in pelican-3.7, and MARKDOWN dict is used instead. See https://github.com/getpelican/pelican-plugins/pull/787 for related discussion.

This change maintains compatibility w/ pelican 3.6.3 and earlier, and works for 3.7